### PR TITLE
Add lastSentMessage to Conversation

### DIFF
--- a/src/main/kotlin/model/Conversation.kt
+++ b/src/main/kotlin/model/Conversation.kt
@@ -1,7 +1,7 @@
 package model
 
 data class Conversation(
-    var id: Int,
+    val id: Int,
     val contacts: MutableList<Contact>,
     val lastSentMessage: Message
 )


### PR DESCRIPTION
<img width="293" alt="screen shot 2019-02-04 at 8 32 04 pm" src="https://user-images.githubusercontent.com/9749143/52200595-5286b280-28bd-11e9-9bb2-99400e2ca09b.png">

Conversations are loaded in 2 passes to get all the info needed.
Trying to do it in one pass has either been slow, complicated,
or both. But that doesn't mean it's not possible.

The way the last message is being fetched is awfully similar
to the way messages are being fetched (as you might expect).
This similarity makes me thing I ought to be able to re-use more
than I am from the sqliteToMessage file. However, it seems
clear enough and fast enough for now, but definitely worth
revisiting.