### PR TITLE
Added validation to settings and provide user feedback

### DIFF
--- a/src/main/kotlin/ui/controllers/ConversationController.kt
+++ b/src/main/kotlin/ui/controllers/ConversationController.kt
@@ -6,18 +6,20 @@ import javafx.beans.property.SimpleBooleanProperty
 import model.Conversation
 import tornadofx.Controller
 import tornadofx.observable
+import ui.viewmodels.SettingsViewModel
 
 class ConversationController : Controller() {
 
     val conversations = mutableListOf<Conversation>().observable()
-    private val settings: SettingsController by inject()
+    private val settings: SettingsViewModel by inject()
     val isLoadingProperty = SimpleBooleanProperty(false)
 
     fun loadConversations() {
+        conversations.clear()
         isLoadingProperty.value = true
         runAsync {
-            val contacts = fetchContacts(settings.addressDB.valueSafe)
-            fetchConversations(settings.messageDB.valueSafe, contacts)
+            val contacts = fetchContacts(settings.addressBookDB.value)
+            fetchConversations(settings.messageDB.value, contacts)
         } ui {
             isLoadingProperty.value = false
             conversations.addAll(it)

--- a/src/main/kotlin/ui/controllers/MessagesController.kt
+++ b/src/main/kotlin/ui/controllers/MessagesController.kt
@@ -8,12 +8,13 @@ import model.Message
 import model.displayName
 import tornadofx.Controller
 import tornadofx.observable
+import ui.viewmodels.SettingsViewModel
 
 class MessagesController : Controller() {
 
     var displayName = SimpleStringProperty()
     val messageList = mutableListOf<Message>().observable()
-    private val settings: SettingsController by inject()
+    private val settings: SettingsViewModel by inject()
     val isLoadingProperty = SimpleBooleanProperty(false)
 
     fun loadConversation(conversation: Conversation) {
@@ -22,7 +23,7 @@ class MessagesController : Controller() {
 
         isLoadingProperty.value = true
         runAsync {
-            fetchMessages(settings.messageDB.valueSafe, conversation)
+            fetchMessages(settings.messageDB.value, conversation)
         } ui {
             messageList.addAll(it)
             isLoadingProperty.value = false

--- a/src/main/kotlin/ui/controllers/SettingsController.kt
+++ b/src/main/kotlin/ui/controllers/SettingsController.kt
@@ -1,9 +1,0 @@
-package ui.controllers
-
-import javafx.beans.property.SimpleStringProperty
-import tornadofx.Controller
-
-class SettingsController : Controller() {
-    val messageDB = SimpleStringProperty("/Users/Kevin/Desktop/chat.db")
-    val addressDB = SimpleStringProperty("/Users/Kevin/Desktop/address.db")
-}

--- a/src/main/kotlin/ui/viewmodels/SettingsViewModel.kt
+++ b/src/main/kotlin/ui/viewmodels/SettingsViewModel.kt
@@ -1,0 +1,42 @@
+package ui.viewmodels
+
+import org.sqlite.SQLiteException
+import tornadofx.ItemViewModel
+import tornadofx.ValidationContext
+import tornadofx.ValidationMessage
+import tornadofx.toProperty
+import java.io.File
+import java.sql.DriverManager
+
+data class SettingsModel(val addressBookDB: String? = null, val messageDB: String? = null)
+
+class SettingsViewModel : ItemViewModel<SettingsModel>() {
+    val addressBookDB = bind { item?.addressBookDB?.toProperty() }
+    val messageDB = bind { item?.messageDB?.toProperty() }
+}
+
+fun validateDB(context: ValidationContext, filename: String?): ValidationMessage? {
+    when {
+        filename.isNullOrBlank() -> return context.error("Cannot be blank")
+        !File(filename).exists() -> return context.error("File does not exist")
+        !File(filename).isFile -> return context.error("Not a file")
+        !File(filename).canRead() -> return context.error("Permission Denied")
+    }
+
+    // connection.isValid returns "true" even if the file is not a database.
+    // Therefore, we must a different approach to test the connection
+    Class.forName("org.sqlite.JDBC")
+    try {
+        val connection = DriverManager.getConnection("jdbc:sqlite:$filename")
+        val tables = connection.metaData.getTables(null, null, "%", null)
+        tables.next()
+    } catch (e: SQLiteException) {
+        // This is rather lazy, but there are a lot of ways the connection could fail
+        // Also, the resultCode messages are better than the exception messages IMO
+        return context.error(e.resultCode.message)
+    }
+
+    return context.success()
+}
+
+

--- a/src/main/kotlin/ui/views/ConversationsPane.kt
+++ b/src/main/kotlin/ui/views/ConversationsPane.kt
@@ -11,10 +11,6 @@ class ConversationsPane : View("Conversations") {
     private val messageController: MessagesController by inject()
     private val controller: ConversationController by inject()
 
-    init {
-        controller.loadConversations()
-    }
-
     override val root = stackpane {
         prefWidth = 275.0
         listview(controller.conversations) {

--- a/src/main/kotlin/ui/views/SettingsPane.kt
+++ b/src/main/kotlin/ui/views/SettingsPane.kt
@@ -1,29 +1,49 @@
 package ui.views
 
+import javafx.scene.paint.Color
 import tornadofx.*
-import ui.controllers.SettingsController
+import ui.controllers.ConversationController
+import ui.viewmodels.SettingsViewModel
+import ui.viewmodels.validateDB
 
 class SettingsPane : View("Settings") {
 
-    private val settings: SettingsController by inject()
+    private val model: SettingsViewModel by inject()
+    private val controller: ConversationController by inject()
 
-    override val root = vbox {
-        vbox {
-            label("Chat DB File Location")
-            hbox {
-                textfield(settings.messageDB) {
-                    prefWidth = 300.0
+    override val root = form {
+        prefWidth = 400.0
+        fieldset {
+            field("Message DB:") {
+                textfield(model.messageDB).validator {
+                    validateDB(this, it)
                 }
-                paddingBottom = 10.0
             }
-            label("Address Book DB File Location")
-            hbox {
-                textfield(settings.addressDB) {
-                    prefWidth = 300.0
+            field("Address DB:") {
+                textfield(model.addressBookDB).validator {
+                    validateDB(this, it)
                 }
-                paddingBottom = 10.0
             }
         }
-        paddingAll = 10.0
+        buttonbar {
+            button("Cancel") {
+                action {
+                    model.rollback()
+                    close()
+                }
+            }
+            button("Save") {
+                enableWhen(model.valid)
+                style {
+                    baseColor = c("#2278ff")
+                    textFill = Color.WHITE
+                }
+                action {
+                    model.commit()
+                    controller.loadConversations()
+                    close()
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
![settings](https://user-images.githubusercontent.com/9749143/52513500-45701780-2c5f-11e9-81ee-5cff18e31e00.gif)

This provides some validation and user feedback when editing
the db file locations. I think it will address the most common
problems, like permission denied and typos. It won't save the user
from putting in the wrong sqlite database though, as the validation
only checks that it is an accessible sqlite database.

The UX can be greatly improved, but that can happen in a later PR.
Right now the error messages are helpful enough and you can't
save the settings unless they are valid.

closes #12 